### PR TITLE
Also attempt to find plugin using prelim url

### DIFF
--- a/prelim.js
+++ b/prelim.js
@@ -11,7 +11,7 @@ if (window.mobilecheck() || kiwi.state.ui.is_touch) {
     let script = document.createElement('script');
     let basePath = '';
     kiwi.state.setting('plugins').forEach((e) => {
-        if (e.name === 'emoji') {
+        if (e.name === 'emoji' || e.url.match('plugin-emoji-prelim.min.js$')) {
             basePath = e.url.split('/');
             basePath.pop();
             basePath = basePath.join('/');


### PR DESCRIPTION
current implementation requires a specific plugin name in config.json, this makes it a little more forgiving as it also attempts to use the url to find its self